### PR TITLE
Fix error in rawdreeg()

### DIFF
--- a/socode.py
+++ b/socode.py
@@ -31,7 +31,7 @@ import struct
 import ctypes
 import glob
 import logging
-
+import datetime
 
 # Logging Support
 #################


### PR DESCRIPTION
rawdreeg function uses date.today() and datetime was not imported. This caused a runtime error.
